### PR TITLE
修复翻页bug #5

### DIFF
--- a/src/main/kotlin/top/jie65535/jcf/util/PagedList.kt
+++ b/src/main/kotlin/top/jie65535/jcf/util/PagedList.kt
@@ -16,6 +16,7 @@ class PagedList<T>(
 
     suspend fun prev(): Array<T> {
         if (pageIndex > 0) {
+            _hasNext = true
             pageIndex--
         }
         return current()
@@ -32,10 +33,15 @@ class PagedList<T>(
         return if (pageIndex < pages.size) {
             pages[pageIndex]
         } else {
-            val data = getPageData(pageIndex)
-            _hasNext = data.size == pageSize
-            pages.add(data)
-            data
+            val data = getPageData(pageIndex * pageSize)
+            if (data.isEmpty()) {
+                _hasNext = false
+                pages[--pageIndex]
+            } else {
+                _hasNext = data.size == pageSize
+                pages.add(data)
+                data
+            }
         }
     }
 }


### PR DESCRIPTION
- 更正传递给 cf 接口的索引
- 修复往前翻页时缺失“下一页”文本的问题